### PR TITLE
fix belongs_to validation errors with rails 5

### DIFF
--- a/app/models/advert_selector/banner.rb
+++ b/app/models/advert_selector/banner.rb
@@ -6,7 +6,7 @@ module AdvertSelector
 
     belongs_to :placement, :inverse_of => :banners
 
-    has_many :helper_items, -> { order(:position) }, :dependent => :destroy
+    has_many :helper_items, -> { order(:position) }, :dependent => :destroy, inverse_of: :banner
     accepts_nested_attributes_for :helper_items
 
     scope :find_future, lambda {

--- a/app/models/advert_selector/helper_item.rb
+++ b/app/models/advert_selector/helper_item.rb
@@ -5,7 +5,7 @@ module AdvertSelector
     #belongs_to :master, :polymorphic => true
     #acts_as_list :scope => [:master_id, :master_type]
 
-    belongs_to :banner, :class_name => 'AdvertSelector::Banner'
+    belongs_to :banner, :class_name => 'AdvertSelector::Banner', inverse_of: :helper_items
     acts_as_list :scope => :banner_id
 
 


### PR DESCRIPTION
Hello 

During the creation of a new banner, it fails with the following validation error: "Helper item banner must exist".
This happens because i'm using `belongs_to` is required by default in rails 5

NB: i'm using RAILS 5.2

